### PR TITLE
not erase the correct fd from conns

### DIFF
--- a/pink/src/holy_thread.cc
+++ b/pink/src/holy_thread.cc
@@ -321,7 +321,7 @@ void HolyThread::ProcessNotifyEvents(const pink::PinkFiredEvent* pfe) {
           conn = nullptr;
           {
             slash::WriteLock l(&rwlock_);
-            conns_.erase(pfe->fd);
+            conns_.erase(fd);
           }
         }
       }


### PR DESCRIPTION
1. when fd be closed ,but not erase this connection from  map conns. because pfe->fd was not equal fd. 
   if a fd be closed, this fd(num) can be return when the process call open() again. 
   so, other fd may be closed  by this thread.  
   
issues:#761. #698. 